### PR TITLE
Fixed typographical error, changed Buddah to Buddha in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Store your town status into ./land.backup file:
     save land.backup
     quit
 
-Add 100 squidport tiles(5000), 999 golden scratchers (44), 999 buddah (9):
+Add 100 squidport tiles(5000), 999 golden scratchers (44), 999 buddha (9):
 
     python tsto.py
     login email@host.com password


### PR DESCRIPTION
schdub, I've corrected a typographical error in the documentation of the [tsto](https://github.com/schdub/tsto) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.